### PR TITLE
Retry listing on certain error messages

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -3,7 +3,7 @@
 // @namespace   https://github.com/Nuklon
 // @author      Nuklon
 // @license     MIT
-// @version     6.7.6
+// @version     6.8.0
 // @description Enhances the Steam Inventory and Steam Market.
 // @include     *://steamcommunity.com/id/*/inventory*
 // @include     *://steamcommunity.com/profiles/*/inventory*
@@ -411,7 +411,7 @@
                 price: price
             },
             success: function(data) {
-                if(data.success === false && isRetryMessage(data.message)) {
+                if (data.success === false && isRetryMessage(data.message)) {
                     callback(ERROR_FAILED, data);
                 } else {
                     callback(ERROR_SUCCESS, data);
@@ -1030,7 +1030,6 @@
 
     function isRetryMessage(message) {
         var messageList = [
-            "You have too many listings pending confirmation. Please confirm or cancel some before attempting to list more.",
             "You cannot sell any items until your previous action completes.",
             "There was a problem listing your item. Refresh the page and try again.",
             "We were unable to contact the game's item server. The game's item server may be down or Steam may be experiencing temporary connectivity issues. Your listing has not been created. Refresh the page and try again."

--- a/code.user.js
+++ b/code.user.js
@@ -1032,7 +1032,8 @@
         var messageList = [
             "You have too many listings pending confirmation. Please confirm or cancel some before attempting to list more.",
             "You cannot sell any items until your previous action completes.",
-            "There was a problem listing your item. Refresh the page and try again."
+            "There was a problem listing your item. Refresh the page and try again.",
+            "We were unable to contact the game's item server. The game's item server may be down or Steam may be experiencing temporary connectivity issues. Your listing has not been created. Refresh the page and try again."
         ];
 
         return messageList.indexOf(message) !== -1;

--- a/code.user.js
+++ b/code.user.js
@@ -1135,8 +1135,8 @@
                                 ' - ' +
                                 itemName +
                                 ' retrying listing because ' +
-                                data.message
-                            );
+                                data.message[0].toLowerCase() +
+                                data.message.slice(1));
 
                             totalNumberOfProcessedQueueItems--;
                             sellQueue.unshift(task);


### PR DESCRIPTION
This addresses issues #109 and #115 

When appropriate, depending on the error message, this will re-add a listing to the sell queue and then pause the queue for a few seconds.  In effect, this will pause the queue while 250 listings are awaiting confirmation.  It will also retry until success for certain error messages which tell the user to either wait or retry.

The errors received from Steam are represented only by localized strings, and so this change will only impact English speakers until other language strings are added to ``messageList``.  Retry until success will only happen when selling from the Inventory page.  No changes where made to what happens on error when selling from a Market Page.  However, now that an error is being reported, it should retry on the first error and report a failure on the second error before moving on.

The "There was a problem listing your item..." message can occur if the listing is invalid.  For example, trying to sell below $0.03.  Lately, this message appears frequently and randomly, and not because the listing is invalid.  Reattempting the listing will eventually succeed as long as the listing is valid.  If the listing is invalid, then the script will loop forever under this change, however the script should not be generating invalid listings under normal usage. 