### PR TITLE
Fixes #112 "View in Community Market" not showing on other games inventories.

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -1876,8 +1876,10 @@
                     $('#' + item_info_id + '_item_market_actions > div').after(groupMain);
 
                     var ownerActions = $('#' + item_info_id + '_item_owner_actions');
+                    // ownerActions is hidden on other games' inventories, we need to show it to have a "Market" buttom visible
+                    ownerActions.show();
 
-                    ownerActions.append('<br/> <a class="btn_small btn_grey_white_innerfade" href="/market/listings/' + appid + '/' + market_hash_name + '"><span>View in Community Market</span></a>');
+                    ownerActions.append('<a class="btn_small btn_grey_white_innerfade" href="/market/listings/' + appid + '/' + market_hash_name + '"><span>View in Community Market</span></a>');
                     $('#' + item_info_id + '_item_market_actions > div:nth-child(1) > div:nth-child(1)').hide();
 
                     var isBoosterPack = getActiveInventory().selectedItem.name.toLowerCase().endsWith('booster pack');

--- a/code.user.js
+++ b/code.user.js
@@ -1876,7 +1876,7 @@
                     $('#' + item_info_id + '_item_market_actions > div').after(groupMain);
 
                     var ownerActions = $('#' + item_info_id + '_item_owner_actions');
-                    // ownerActions is hidden on other games' inventories, we need to show it to have a "Market" buttom visible
+                    // ownerActions is hidden on other games' inventories, we need to show it to have a "Market" button visible
                     ownerActions.show();
 
                     ownerActions.append('<a class="btn_small btn_grey_white_innerfade" href="/market/listings/' + appid + '/' + market_hash_name + '"><span>View in Community Market</span></a>');


### PR DESCRIPTION
Steam items have elements with the class `item_owner_actions visible` but other games inventories do not, and the market button is added to it.  
That element is hidden on almost all other games I've checked, causing the problem described in other Issues.  

Still not sure if a whole new button is the right way to have the "View in Community Market" link, but this fixes the missing problem.  
Also removed a break tag `<br/>`  on the added button because it causes unnecessary space between buttons on other items, and it is still normal for the steam ones.

Fixes #112

