### PR TITLE
removed quicksell btn for too low (invalid) prices

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -1944,7 +1944,10 @@
                     }
 
                     if (histogram != null && histogram.lowest_sell_order != null) {
-                        prices.push(parseInt(histogram.lowest_sell_order) - 1);
+                        //transaction volume must be separable into three or more parts (no matter if equal): valve+publisher+seller
+                        if (parseInt(histogram.lowest_sell_order) > 3) {
+                            prices.push(parseInt(histogram.lowest_sell_order) - 1);
+                        }
                         prices.push(parseInt(histogram.lowest_sell_order));
                     }
 

--- a/code.user.js
+++ b/code.user.js
@@ -1944,7 +1944,7 @@
                     }
 
                     if (histogram != null && histogram.lowest_sell_order != null) {
-                        //transaction volume must be separable into three or more parts (no matter if equal): valve+publisher+seller
+                        // Transaction volume must be separable into three or more parts (no matter if equal): valve+publisher+seller.
                         if (parseInt(histogram.lowest_sell_order) > 3) {
                             prices.push(parseInt(histogram.lowest_sell_order) - 1);
                         }


### PR DESCRIPTION
The helper creates buttons that will sell an item for 0,02 EUR/USD which is too low for creating a transaction. The reason why everything in the market costs $0,03 or more is because of the maths behind when splitting revenue into 3 parts. I am not sure how high the minimum is for other (especially low-value) currencies, but this should be a beginning.  
Great script btw!