### PR TITLE
Fix incorrect MarketHashName and getCurrentMarketItemNameId error and remove purchase order error

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -717,7 +717,7 @@
         var url = window.location.protocol + '//steamcommunity.com/market/listings/' + appid + '/' + market_name;
         $.get(url,
                 function(page) {
-                    var matches = /Market_LoadOrderSpread\( (.+) \);/.exec(page);
+                    var matches = /Market_LoadOrderSpread\( (\d+) \);/.exec(page);
                     if (matches == null) {
                         callback(ERROR_DATA);
                         return;

--- a/code.user.js
+++ b/code.user.js
@@ -469,7 +469,25 @@
                 callback(ERROR_SUCCESS, data);
             },
             error: function() {
-                return callback(ERROR_FAILED);
+                $.ajax({
+                    type: "POST",
+                    url: window.location.protocol + '//steamcommunity.com/market/cancelbuyorder/',
+                    data: {
+                        sessionid: sessionId,
+                        buy_orderid: item
+                    },
+                    success: function (data) {
+                        callback(ERROR_SUCCESS, data);
+                    },
+                    error: function () {
+                        return callback(ERROR_FAILED);
+                    },
+                    crossDomain: true,
+                    xhrFields: {
+                        withCredentials: true
+                    },
+                    dataType: 'json'
+                });
             },
             crossDomain: true,
             xhrFields: {

--- a/code.user.js
+++ b/code.user.js
@@ -34,17 +34,22 @@
         "1186460-Zang Guang (Trading Card)": "1186460-Zang Guang",
         "1186460-Zhang Chengyuan (Trading Card)": "1186460-Zhang Chengyuan",
         "1186460-Hua Jieyu (Trading Card)": "1186460-Hua Jieyu",
+        "1186460-Lv Lingji (Foil Trading Card)": "1186460-Lv Lingji (Foil)",
+        "1186460-Zang Guang (Foil Trading Card)": "1186460-Zang Guang (Foil)",
+        "1186460-Zhang Chengyuan (Foil Trading Card)": "1186460-Zhang Chengyuan (Foil)",
+        "1186460-Hua Jieyu (Foil Trading Card)": "1186460-Hua Jieyu (Foil)",
         "1186460-Archer (Profile Background)": "1186460-Archer",
         "1186460-Saber (Profile Background)": "1186460-Saber",
         "1186460-Assassin (Profile Background)": "1186460-Assassin",
         "1186460-Berserker (Profile Background)": "1186460-Berserker",
         "1186460-Heroine (Profile Background)": "1186460-Heroine",
         "1345740-mengyetong (Trading Card)": "1345740-mengyetong",
-        "340220-LMG Soldier #2 (Foil)": "340220-LMG%20Soldier%20%232%20(Foil)",
+        "1345740-mengyetong (Foil Trading Card)": "1345740-mengyetong (Foil)",
     }
 
     var ChangeSameHashNameCard = {
         "1478160-Irin (Trading Card)": true,
+        "1478160-Irin (Foil Trading Card)": true,
     }
 
     var DateTime = luxon.DateTime;

--- a/code.user.js
+++ b/code.user.js
@@ -43,7 +43,7 @@
         "340220-LMG Soldier #2 (Foil)": "340220-LMG%20Soldier%20%232%20(Foil)",
     }
 
-    var SameHashNameCard = {
+    var ChangeSameHashNameCard = {
         "1478160-Irin (Trading Card)": true,
     }
 
@@ -1688,7 +1688,7 @@
             var failed = 0;
             var itemName = item.name || item.description.name;
 
-            if(SameHashNameCard[item.description.market_hash_name]){
+            if(ChangeSameHashNameCard[item.description.market_hash_name]){
                 let link = item.owner_actions[1].link;
                 let assetid_values = link.match(/'%assetid%',\s*((?:\d+,?\s*)+)/)[1];
                 let item_type = assetid_values.split(",")[1].trim();
@@ -2483,7 +2483,7 @@
                 }
             };
 
-            if(SameHashNameCard[item.description.market_hash_name]){
+            if(ChangeSameHashNameCard[item.description.market_hash_name]){
                 let link = asset.owner_actions[1].link;
                 let assetid_values = link.match(/'%assetid%',\s*((?:\d+,?\s*)+)/)[1];
                 let item_type = assetid_values.split(",")[1].trim();

--- a/code.user.js
+++ b/code.user.js
@@ -29,6 +29,24 @@
 (function($, async) {
     $.noConflict(true);
 
+    var ChangeHashName = {
+        "1186460-Lv Lingji (Trading Card)": "1186460-Lv Lingji",
+        "1186460-Zang Guang (Trading Card)": "1186460-Zang Guang",
+        "1186460-Zhang Chengyuan (Trading Card)": "1186460-Zhang Chengyuan",
+        "1186460-Hua Jieyu (Trading Card)": "1186460-Hua Jieyu",
+        "1186460-Archer (Profile Background)": "1186460-Archer",
+        "1186460-Saber (Profile Background)": "1186460-Saber",
+        "1186460-Assassin (Profile Background)": "1186460-Assassin",
+        "1186460-Berserker (Profile Background)": "1186460-Berserker",
+        "1186460-Heroine (Profile Background)": "1186460-Heroine",
+        "1345740-mengyetong (Trading Card)": "1345740-mengyetong",
+        "340220-LMG Soldier #2 (Foil)": "340220-LMG%20Soldier%20%232%20(Foil)",
+    }
+
+    var SameHashNameCard = {
+        "1478160-Irin (Trading Card)": true,
+    }
+
     var DateTime = luxon.DateTime;
 
     const STEAM_INVENTORY_ID = 753;
@@ -1670,6 +1688,17 @@
             var failed = 0;
             var itemName = item.name || item.description.name;
 
+            if(SameHashNameCard[item.description.market_hash_name]){
+                let link = item.owner_actions[1].link;
+                let assetid_values = link.match(/'%assetid%',\s*((?:\d+,?\s*)+)/)[1];
+                let item_type = assetid_values.split(",")[1].trim();
+                item.description.market_hash_name=item.description.market_hash_name+'-'+item_type;
+            }
+
+            if (ChangeHashName[item.description.market_hash_name]) {
+                item.description.market_hash_name = ChangeHashName[item.description.market_hash_name]
+            }
+
             market.getPriceHistory(item,
                 true,
                 function(err, history, cachedHistory) {
@@ -2453,6 +2482,17 @@
                     market_hash_name: market_hash_name
                 }
             };
+
+            if(SameHashNameCard[item.description.market_hash_name]){
+                let link = asset.owner_actions[1].link;
+                let assetid_values = link.match(/'%assetid%',\s*((?:\d+,?\s*)+)/)[1];
+                let item_type = assetid_values.split(",")[1].trim();
+                item.description.market_hash_name=item.description.market_hash_name+'-'+item_type;
+            }
+
+            if (ChangeHashName[item.description.market_hash_name]) {
+                item.description.market_hash_name = ChangeHashName[item.description.market_hash_name]
+            }
 
             var failed = 0;
 


### PR DESCRIPTION
![S_Z63B@KBWLUDW S@}DBJEH](https://github.com/Nuklon/Steam-Economy-Enhancer/assets/72839560/07d88590-8ffe-4167-a89b-1970c8d5e158)
Before change MarketHashName, we can only obtain the incorrect MarketHashName.
By using ChangeHashName, we obtain the correct MarketHashName like below:
![)SGRANU SBN9NMDJWND$1RS](https://github.com/Nuklon/Steam-Economy-Enhancer/assets/72839560/6fee83a5-d1f2-4426-9c05-06392a1a82d1)
