### PR TITLE
Total number of items on trade window, Select 5/25/100 on Community Market listing page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It adds the following features to the Steam Inventory:
 
 It adds the following features to the Steam Tradeoffers:
 
-*    A summary of all items from both parties that includes total number of items, number of unique items and item count breakdown (how many of each items there are)
+*    A summary of all items from both parties that includes total number of items, number of unique items and item count breakdown (how many of each item there are)
 *    Select all items of the current page.
 *    Shows the lowest listed price for each inventory item.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A free userscript to enhance your Steam Inventory, Steam Market and Steam Tradeo
 It adds the following features to the Steam Market:
 
 *    Detect overpriced and underpriced items.
-*    Select all (overpriced) items and remove them at once.
+*    Select 5/25/100/all (overpriced) items and remove them at once.
 *    (Automatically) relist overpriced items.
 *    Sort and search items by name, price or date.
 *    Total price for listings, as seller and buyer.
@@ -23,6 +23,7 @@ It adds the following features to the Steam Inventory:
 It adds the following features to the Steam Tradeoffers:
 
 *    A summary of all items from both parties.
+	- Includes total number of items, number of unique items and item count breakdown (how many of each items there are)
 *    Select all items of the current page.
 *    Shows the lowest listed price for each inventory item.
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ It adds the following features to the Steam Inventory:
 
 It adds the following features to the Steam Tradeoffers:
 
-*    A summary of all items from both parties.
-	* Includes total number of items, number of unique items and item count breakdown (how many of each items there are)
+*    A summary of all items from both parties that includes total number of items, number of unique items and item count breakdown (how many of each items there are)
 *    Select all items of the current page.
 *    Shows the lowest listed price for each inventory item.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It adds the following features to the Steam Inventory:
 It adds the following features to the Steam Tradeoffers:
 
 *    A summary of all items from both parties.
-	- Includes total number of items, number of unique items and item count breakdown (how many of each items there are)
+	* Includes total number of items, number of unique items and item count breakdown (how many of each items there are)
 *    Select all items of the current page.
 *    Shows the lowest listed price for each inventory item.
 

--- a/code.user.js
+++ b/code.user.js
@@ -3135,10 +3135,27 @@
             // Sell orders.
             $('.my_market_header').first().append(
                 '<div class="market_listing_buttons">' +
+
                 '<a class="item_market_action_button item_market_action_button_green select_all market_listing_button">' +
                 '<span class="item_market_action_button_contents" style="text-transform:none">Select all</span>' +
                 '</a>' +
                 '<span class="separator-small"></span>' +
+
+                '<a class="item_market_action_button item_market_action_button_green select_five_from_page market_listing_button">' +
+                '<span class="item_market_action_button_contents" style="text-transform:none">Select 5</span>' +
+                '</a>' +
+                '<span class="separator-small"></span>' +
+
+                '<a class="item_market_action_button item_market_action_button_green select_twentyfive_from_page market_listing_button">' +
+                '<span class="item_market_action_button_contents" style="text-transform:none">Select 25</span>' +
+                '</a>' +
+                '<span class="separator-small"></span>' +
+
+                '<a class="item_market_action_button item_market_action_button_green select_hundred_from_page market_listing_button">' +
+                '<span class="item_market_action_button_contents" style="text-transform:none">Select 100</span>' +
+                '</a>' +
+                '<span class="separator-small"></span>' +
+
                 '<a class="item_market_action_button item_market_action_button_green remove_selected market_listing_button">' +
                 '<span class="item_market_action_button_contents" style="text-transform:none">Remove selected</span>' +
                 '</a>' +
@@ -3146,13 +3163,16 @@
                 '<span class="item_market_action_button_contents" style="text-transform:none">Relist selected</span>' +
                 '</a>' +
                 '<span class="separator-small"></span>' +
+
                 '<a class="item_market_action_button item_market_action_button_green relist_overpriced market_listing_button market_listing_button_right">' +
                 '<span class="item_market_action_button_contents" style="text-transform:none">Relist overpriced</span>' +
                 '</a>' +
                 '<span class="separator-small"></span>' +
+
                 '<a class="item_market_action_button item_market_action_button_green select_overpriced market_listing_button market_listing_button_right">' +
                 '<span class="item_market_action_button_contents" style="text-transform:none">Select overpriced</span>' +
                 '</a>' +
+
                 '</div>');
 
             // Listings confirmations and buy orders.
@@ -3186,6 +3206,66 @@
 
                 for (var i = 0; i < marketList.matchingItems.length; i++) {
                     $('.market_select_item', marketList.matchingItems[i].elm).prop('checked', !invert);
+                }
+
+                updateMarketSelectAllButton();
+            });
+
+            $('.select_five_from_page').on('click', '*', function() {
+                var selectionGroup = $(this).parent().parent().parent().parent();
+                var marketList = getListFromContainer(selectionGroup);
+
+                var invert = $('.market_select_item:checked', selectionGroup).length == $('.market_select_item', selectionGroup).length;
+
+                var count = 0
+                for (var i = 0; i < marketList.matchingItems.length; i++) {
+                    if(count == 5){
+                        break;
+                    }
+                    if(!$('.market_select_item', marketList.matchingItems[i].elm).prop('checked')){
+                        $('.market_select_item', marketList.matchingItems[i].elm).prop('checked', true);
+                        count += 1;
+                    }
+                }
+
+                updateMarketSelectAllButton();
+            });
+
+            $('.select_twentyfive_from_page').on('click', '*', function() {
+                var selectionGroup = $(this).parent().parent().parent().parent();
+                var marketList = getListFromContainer(selectionGroup);
+
+                var invert = $('.market_select_item:checked', selectionGroup).length == $('.market_select_item', selectionGroup).length;
+
+                var count = 0
+                for (var i = 0; i < marketList.matchingItems.length; i++) {
+                    if(count == 25){
+                        break;
+                    }
+                    if(!$('.market_select_item', marketList.matchingItems[i].elm).prop('checked')){
+                        $('.market_select_item', marketList.matchingItems[i].elm).prop('checked', true);
+                        count += 1;
+                    }
+                }
+
+                updateMarketSelectAllButton();
+            });
+
+            $('.select_hundred_from_page').on('click', '*', function() {
+                var selectionGroup = $(this).parent().parent().parent().parent();
+                var marketList = getListFromContainer(selectionGroup);
+
+                var invert = $('.market_select_item:checked', selectionGroup).length == $('.market_select_item', selectionGroup).length;
+
+                var count = 0
+                for (var i = 0; i < marketList.matchingItems.length; i++) {
+                    if(count == 100){
+                        break;
+                    }
+                    if(!$('.market_select_item', marketList.matchingItems[i].elm).prop('checked')){
+                        $('.market_select_item', marketList.matchingItems[i].elm).prop('checked', true);
+                        count += 1;
+                    }
                 }
 
                 updateMarketSelectAllButton();
@@ -3352,12 +3432,13 @@
             }).reverse();
 
             var totalText = '<strong>Number of unique items: ' + sortable.length + ', worth ' + (totalPrice / 100).toFixed(2) + currencySymbol + '<br/><br/></strong>';
-            var totalNumOfItems
+            var totalNumOfItems = 0;
             for (var i = 0; i < sortable.length; i++) {
                 totalText += sortable[i][1] + 'x ' + sortable[i][0] + '<br/>';
                 totalNumOfItems += sortable[i][1];
             }
             totalText += '<br/><strong>Total items: ' + totalNumOfItems + '</strong><br/>';
+
             return totalText;
         }
     }

--- a/code.user.js
+++ b/code.user.js
@@ -3351,12 +3351,13 @@
                 return a[1] - b[1];
             }).reverse();
 
-            var totalText = '<strong>Number of items: ' + sortable.length + ', worth ' + (totalPrice / 100).toFixed(2) + currencySymbol + '<br/><br/></strong>';
-
+            var totalText = '<strong>Number of unique items: ' + sortable.length + ', worth ' + (totalPrice / 100).toFixed(2) + currencySymbol + '<br/><br/></strong>';
+            var totalNumOfItems
             for (var i = 0; i < sortable.length; i++) {
                 totalText += sortable[i][1] + 'x ' + sortable[i][0] + '<br/>';
+                totalNumOfItems += sortable[i][1];
             }
-
+            totalText += '<br/><strong>Total items: ' + totalNumOfItems + '</strong><br/>';
             return totalText;
         }
     }


### PR DESCRIPTION
### Trade Window
Displays the total number of items in a trade, rather than just the number of unique items, and replaces the old text with "Number of unique items" instead of "Number of items".

![image](https://github.com/Nuklon/Steam-Economy-Enhancer/assets/5371012/00419925-1522-4e16-b541-c18f937ae488)

### Community Market Listings
Added "Select 5/25/100" to the Community Market Page allowing people with tons of items to bulk select without clicking on each one or selecting all their listings.

![image](https://github.com/Nuklon/Steam-Economy-Enhancer/assets/5371012/38dc9a0c-f121-43a0-b16c-a7e44dfb9c2e)


