### PR TITLE
fix: use encodeURIComponent when building multisell URL

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -1585,7 +1585,7 @@
 
                 var itemsString = '';
                 for (var itemName in itemsWithQty) {
-                    itemsString += '&items[]=' + encodeURI(itemName) + '&qty[]=' + itemsWithQty[itemName];
+                    itemsString += '&items[]=' + encodeURIComponent(itemName) + '&qty[]=' + itemsWithQty[itemName];
                 }
 
                 var baseUrl = 'https://steamcommunity.com/market/multisell';


### PR DESCRIPTION
Currently, 'Sell item Manual' is broken when there are some characters, such as ampersand (e.g. Dreams & Nightmares Case), in the item name. Replacing `encodeURI` with `encodeURIComponent` should fix this.