### PR TITLE
 2FA listing confirmations

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -4071,7 +4071,7 @@
                 <span id=sdaFileResult style="opacity:${getSettingWithDefault(SETTING_CONFIRMATOR) ? '1' : '0'};transition:opacity 0.2s linear;margin-left:10px">${(getSettingWithDefault(SETTING_CONFIRMATOR) ? 'Loaded as '+ JSON.parse(getSettingWithDefault(SETTING_CONFIRMATOR)).account_name : '')}</span>
             </div>
         </div>`).on('change', `#${SETTING_CONFIRMATOR}`, function() {
-            const [file] = this.file;
+            const [file] = this.files;
             const reader = new FileReader();
 
             reader.addEventListener('load', () => {


### PR DESCRIPTION
Add support for automatic listing confirmation.

All the main code of the _Confirmator_ is located in `//region Confirmator.`
If necessary, I can rewrite it (class) for the pre-ES6 standard...

For the _Confirmator_ to work, a .maFile should be uploaded in the settings.
![How it should work](https://i.imgur.com/gB7Bm8h.png)

I only extract following data from .maFile:
- account_name _(only to display which .maFile was loaded)_
- device_id _(needed to generate verification codes)_
- identity_secret _(needed to generate verification codes)_

The confirmation procedure itself is included in the `sellQueue` function

According to the results of my tests, the code works more or less stable.