### PR TITLE
Do not fetch price history if price algorithm does not require it

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -554,6 +554,13 @@
     // Prices are ordered by oldest to most recent.
     // Price is inclusive of fees.
     SteamMarket.prototype.getPriceHistory = function(item, cache, callback) {
+        const shouldUseAverage = getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 1;
+
+        if (!shouldUseAverage) {
+            // The price history is only used by the "average price" calculation
+            return callback(ERROR_SUCCESS, null, true);
+        }
+
         try {
             const market_name = getMarketHashName(item);
             if (market_name == null) {


### PR DESCRIPTION
It matches the code in `calculateSellPriceBeforeFees`

```
const shouldUseAverage = getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 1;

else if (historyPrice < listingPrice || !shouldUseAverage) {
      calculatedPrice = listingPrice;
}
```

`calculateAverageHistoryPriceBeforeFees` returns 0 if history is null.