### PR TITLE
Do not reload the page when removing a market listing

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -3491,12 +3491,6 @@
                 updateMarketSelectAllButton();
             });
 
-            $('#market_removelisting_dialog_accept').on('click', '*', () => {
-                // This is when a user removed an item through the Remove/Cancel button.
-                // Ideally, it should remove this item from the list (instead of just the UI element which Steam does), but I'm not sure how to get the current item yet.
-                window.location.reload();
-            });
-
             $('.select_overpriced').on('click', '*', function() {
                 const selectionGroup = $(this).parent().parent().parent().parent();
                 const marketList = getListFromContainer(selectionGroup);


### PR DESCRIPTION
Valve's code removes the listing via `$$('.listing_' + this.m_ulListingId)` which seems to work just fine with the paginated table, so I don't see a reason to reload the page here.