### PR TITLE
Ignore listing by price

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -1303,10 +1303,11 @@
                 const digits = getNumberOfDigits(totalNumberOfQueuedItems);
                 const itemId = task.item.assetid || task.item.id;
                 const itemName = task.item.name || task.item.description.name;
+                const itemNameWithAmount = task.item.amount == 1 ? itemName : `${task.item.amount}x ${itemName}`;
                 const padLeft = `${padLeftZero(`${totalNumberOfProcessedQueueItems}`, digits)} / ${totalNumberOfQueuedItems}`;
 
                 if (getSettingWithDefault(SETTING_PRICE_MIN_LIST_PRICE) * 100 >= market.getPriceIncludingFees(task.sellPrice)) {
-                    logDOM(`${padLeft} - ${itemName} is not listed due to ignoring price settings.`);
+                    logDOM(`${padLeft} - ${itemNameWithAmount} is not listed due to ignoring price settings.`);
                     $(`#${task.item.appid}_${task.item.contextid}_${itemId}`).css('background', COLOR_PRICE_NOT_CHECKED);
                     next();
                     return;
@@ -1322,8 +1323,7 @@
                         const callback = () => setTimeout(() => next(), getRandomInt(1000, 1500));
 
                         if (success) {
-                            const amount = task.item.amount == 1 ? '' : `${task.item.amount}x `;
-                            logDOM(`${padLeft} - ${amount}${itemName} listed for ${formatPrice(market.getPriceIncludingFees(task.sellPrice) * task.item.amount)}, you will receive ${formatPrice(task.sellPrice * task.item.amount)}.`);
+                            logDOM(`${padLeft} - ${itemNameWithAmount} listed for ${formatPrice(market.getPriceIncludingFees(task.sellPrice) * task.item.amount)}, you will receive ${formatPrice(task.sellPrice * task.item.amount)}.`);
                             $(`#${task.item.appid}_${task.item.contextid}_${itemId}`).css('background', COLOR_SUCCESS);
 
                             totalPriceWithoutFeesOnMarket += task.sellPrice * task.item.amount;
@@ -1336,7 +1336,7 @@
                         }
 
                         if (message && isRetryMessage(message)) {
-                            logDOM(`${padLeft} - ${itemName} retrying listing because: ${message.charAt(0).toLowerCase()}${message.slice(1)}`);
+                            logDOM(`${padLeft} - ${itemNameWithAmount} retrying listing because: ${message.charAt(0).toLowerCase()}${message.slice(1)}`);
 
                             totalNumberOfProcessedQueueItems--;
                             sellQueue.unshift(task);
@@ -1348,7 +1348,7 @@
                             return;
                         }
 
-                        logDOM(`${padLeft} - ${itemName} not added to market${message ? ` because:  ${message.charAt(0).toLowerCase()}${message.slice(1)}` : '.'}`);
+                        logDOM(`${padLeft} - ${itemNameWithAmount} not added to market${message ? ` because:  ${message.charAt(0).toLowerCase()}${message.slice(1)}` : '.'}`);
                         $(`#${task.item.appid}_${task.item.contextid}_${itemId}`).css('background', COLOR_ERROR);
 
                         callback();

--- a/code.user.js
+++ b/code.user.js
@@ -4,7 +4,7 @@
 // @namespace    https://github.com/Nuklon
 // @author       Nuklon
 // @license      MIT
-// @version      7.1.0
+// @version      7.1.1
 // @description  Enhances the Steam Inventory and Steam Market.
 // @match        https://steamcommunity.com/id/*/inventory*
 // @match        https://steamcommunity.com/profiles/*/inventory*

--- a/code.user.js
+++ b/code.user.js
@@ -1299,6 +1299,7 @@
         const sellQueue = async.queue(
             (task, next) => {
                 totalNumberOfProcessedQueueItems++;
+                
                 const digits = getNumberOfDigits(totalNumberOfQueuedItems);
                 const itemId = task.item.assetid || task.item.id;
                 const itemName = task.item.name || task.item.description.name;
@@ -1308,9 +1309,9 @@
                     logDOM(`${padLeft} - ${itemName} is not listed due to ignoring price settings.`);
                     $(`#${task.item.appid}_${task.item.contextid}_${itemId}`).css('background', COLOR_PRICE_NOT_CHECKED);
                     next();
-
                     return;
                 }
+                
                 market.sellItem(
                     task.item,
                     task.sellPrice,


### PR DESCRIPTION
Ignore listing according to the final price.

Setup menu example
![Setup menu example](https://github.com/user-attachments/assets/141fc14c-945e-47c1-aa2c-bdadc85bfb4b)

"Sell all" example
!["Sell all" example](https://github.com/user-attachments/assets/19ae35e0-4a55-4078-8b31-1f57d1309890)

At the moment, this pull request has a conflict with my another pull request #233. So, depending on what is accepted and how, I will fix my code.