### PR TITLE
Fix a bug with item.amount sometimes being undefined (#250)

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -510,7 +510,7 @@
                 appid: item.appid,
                 contextid: item.contextid,
                 assetid: item.assetid || item.id,
-                amount: item.amount,
+                amount: item.amount || 1,
                 price: price
             },
             responseType: 'json'


### PR DESCRIPTION
Fixes #250. I am getting the 400 rejected response on `/market/sellitem`:

`{"success":false,"message":"Missing parameters in SellItem request"}`

For some reason, `amount` is not sent in the payload:

```
sessionid: ...
appid: 753
contextid: 6
assetid: 34121389221
price: 15
```

However, if I fix this line (503) `amount: item.amount` to `amount: item.amount || 1`, it obviously sends the `1` and returns with a `200` response:

```
{
    "success": true,
    ...
}
``` 

Feel free to ask questions!