### PR TITLE
chore: force users to share the affected URL on bugs.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,6 +8,13 @@ body:
     description: A clear and concise description of what the bug is and what page it happens on. Provide a screenshot and console logs if applicable.
   validations:
     required: true
+    
+- type: input
+  attributes:
+    label: URL
+    description: The complete URL where the problem was found. I.e: https://steamcommunity.com/market/
+  validations:
+    required: true
 
 - type: input
   attributes:


### PR DESCRIPTION
A minor improvement, but I guess is fair to ask for the URL where the problem was found for faster support.