### PR TITLE
fix: syntax error at bug.yml (regression)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -12,7 +12,7 @@ body:
 - type: input
   attributes:
     label: URL
-    description: The complete URL where the problem was found. I.e: https://steamcommunity.com/market/
+    description: "The complete URL where the problem was found. I.e: https://steamcommunity.com/market/"
   validations:
     required: true
 


### PR DESCRIPTION
Fixes:
![image](https://github.com/user-attachments/assets/692a4d72-8458-4475-b73a-73b54b26a1d4)

Introduced by #256
