### PR TITLE
feat: add inventory load spinner

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -2427,9 +2427,24 @@
             for (const child in getActiveInventory().m_rgChildInventories) {
                 items.push(getActiveInventory().m_rgChildInventories[child]);
             }
+
             items.push(getActiveInventory());
 
-            return loadInventories(items);
+            const promise = loadInventories(items);
+
+            if (location.pathname.endsWith('/inventory')) {
+                $('#inventory_items_spinner').remove();
+                
+                $('#inventory_sell_buttons').append(`
+                    <div id="inventory_items_spinner">${spinnerBlock}
+                        <div style="text-align:center">Loading inventory items</div>
+                    </div>`
+                );
+
+                promise.finally(() => $('#inventory_items_spinner').remove());
+            }
+
+            return promise;
         }
 
         // Gets the inventory items from the active inventory.

--- a/code.user.js
+++ b/code.user.js
@@ -2399,30 +2399,25 @@
 
         // Loads the specified inventories.
         function loadInventories(inventories) {
-            return new Promise((resolve) => {
-                inventories.reduce(
-                    (promise, inventory) => {
-                        return promise.then(() => {
-                            // return inventory.LoadCompleteInventory().done(() => { });
+            return Promise.all(inventories.map((inventory) => {
+                return new Promise((resolve) => {
+                    // return inventory.LoadCompleteInventory().done(resolve);
 
-                            // Workaround, until Steam fixes the issue with LoadCompleteInventory.
-                            
-                            if (inventory.m_bFullyLoaded) {
-                                return Promise.resolve();
-                            }
+                    // Workaround, until Steam fixes the issue with LoadCompleteInventory.
 
-                            if (!inventory.m_promiseLoadCompleteInventory) {
-                                inventory.m_promiseLoadCompleteInventory = inventory.LoadUntilConditionMet(() => inventory.m_bFullyLoaded, 2000);
-                            }
+                    if (inventory.m_bFullyLoaded) {
+                        resolve();
 
-                            return inventory.m_promiseLoadCompleteInventory.done(() => { });
-                        });
-                    },
-                    Promise.resolve()
-                );
+                        return;
+                    }
 
-                resolve();
-            });
+                    if (!inventory.m_promiseLoadCompleteInventory) {
+                        inventory.m_promiseLoadCompleteInventory = inventory.LoadUntilConditionMet(() => inventory.m_bFullyLoaded, 2000);
+                    }
+
+                    return inventory.m_promiseLoadCompleteInventory.done(resolve);
+                });
+            }));
         }
 
         // Loads all inventories.


### PR DESCRIPTION
Based on https://github.com/Nuklon/Steam-Economy-Enhancer/pull/274, now possible to add spinner for inventory load.

The main purpose of this - to show users that something going on.
Especially useful on small devices, where Steam's spinner can't be seen (at the bottom of the page).