### PR TITLE
fix: fixed nested inventories load

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -2415,7 +2415,15 @@
                         inventory.m_promiseLoadCompleteInventory = inventory.LoadUntilConditionMet(() => inventory.m_bFullyLoaded, 2000);
                     }
 
-                    return inventory.m_promiseLoadCompleteInventory.done(resolve);
+                    return inventory.m_promiseLoadCompleteInventory.done(() => {
+                        const parent = inventory.m_parentInventory;
+
+                        if (parent != null && Object.values(parent.m_rgChildInventories).every(child => child.m_bFullyLoaded)) {
+                            parent.m_bFullyLoaded = true;
+                        }
+                        
+                        resolve();
+                    });
                 });
             }));
         }


### PR DESCRIPTION
after merging https://github.com/Nuklon/Steam-Economy-Enhancer/pull/274, functions now actually waits before inventory would be loaded, rather then before

but nested inventories (CAppwideInventory) are not marks as fully loaded at `LoadUntilConditionMet` calls

so, script stucks indefinitely at inventories load at nested inventory (like 753_0)

this pr fixed that with a tiny trick