### PR TITLE
fix: reset progress bar in market listings

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -3130,7 +3130,7 @@
                 logConsole(`Skipping item ${item.elm.id} (not a buy or sell order)`);
             });
 
-            if (totalSellOrderAmount > 0 || totalBuyOrderAmount > 0) {
+            if (totalSellOrderAmount > 0) {
                 increaseMarketProgressMax();
             }
 


### PR DESCRIPTION
This PR fixes market progress bar after https://github.com/Nuklon/Steam-Economy-Enhancer/pull/279

Buy-orders retrieves without pagination, so they can't update progress bar later like sell-orders do.