### PR TITLE
feat: don't update removing listings

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -2824,8 +2824,7 @@
         );
 
         function marketOverpricedQueueWorker(item, ignoreErrors, callback) {
-            let listingUI = getListingFromLists(item.listing);
-
+            let listingUI = getListingFromLists(item.listing)
             if (listingUI == null) {
                 logConsole(`Listing ${item.listing} not found in the lists, skipping.`);
 

--- a/code.user.js
+++ b/code.user.js
@@ -3632,7 +3632,7 @@
                         const listingid = replaceNonNumbers(marketList.matchingItems[i].values().market_listing_item_name);
 
                         const listingUI = $(getListingFromLists(listingid).elm);
-                        listingUI.addClass('not_checked');
+                        listingUI.addClass('removing');
                        
                         marketRemoveQueue.push(listingid);
                         increaseMarketProgressMax();

--- a/code.user.js
+++ b/code.user.js
@@ -2825,7 +2825,17 @@
         );
 
         function marketOverpricedQueueWorker(item, ignoreErrors, callback) {
-            const listingUI = getListingFromLists(item.listing).elm;
+            let listingUI = getListingFromLists(item.listing);
+
+            if (listingUI == null) {
+                logConsole(`Listing ${item.listing} not found in the lists, skipping.`);
+
+                callback(true);
+
+                return;
+            }
+
+            listingUI = listingUI.elm;
 
             market.removeListing(
                 item.listing, false,

--- a/code.user.js
+++ b/code.user.js
@@ -2680,7 +2680,7 @@
             const game_name = asset.type;
             const price = getPriceValueAsInt($('.market_listing_price > span:nth-child(1) > span:nth-child(1)', listingUI).text());
 
-            if (price <= getSettingWithDefault(SETTING_PRICE_MIN_CHECK_PRICE) * 100 || listingUI.hasClass('not_checked')) {
+            if (price <= getSettingWithDefault(SETTING_PRICE_MIN_CHECK_PRICE) * 100 || listingUI.hasClass('removing')) {
                 $('.market_listing_my_price', listingUI).last().css('background', COLOR_PRICE_NOT_CHECKED);
                 $('.market_listing_my_price', listingUI).last().prop('title', 'The price is not checked.');
                 listingUI.addClass('not_checked');

--- a/code.user.js
+++ b/code.user.js
@@ -2666,12 +2666,22 @@
             const market_hash_name = getMarketHashName(asset);
             const appid = listing.appid;
 
-            const listingUI = $(getListingFromLists(listing.listingid).elm);
+            let listingUI = getListingFromLists(listing.listingid);
+
+            if (listingUI == null) {
+                logConsole(`Listing ${listing.listingid} not found in the lists, skipping.`);
+
+                callback(true, true);
+
+                return;
+            }
+
+            listingUI = $(listingUI.elm);
 
             const game_name = asset.type;
             const price = getPriceValueAsInt($('.market_listing_price > span:nth-child(1) > span:nth-child(1)', listingUI).text());
 
-            if (price <= getSettingWithDefault(SETTING_PRICE_MIN_CHECK_PRICE) * 100) {
+            if (price <= getSettingWithDefault(SETTING_PRICE_MIN_CHECK_PRICE) * 100 || listingUI.hasClass('not_checked')) {
                 $('.market_listing_my_price', listingUI).last().css('background', COLOR_PRICE_NOT_CHECKED);
                 $('.market_listing_my_price', listingUI).last().prop('title', 'The price is not checked.');
                 listingUI.addClass('not_checked');
@@ -3612,6 +3622,10 @@
                 for (let i = 0; i < marketList.matchingItems.length; i++) {
                     if ($('.market_select_item', $(marketList.matchingItems[i].elm)).prop('checked')) {
                         const listingid = replaceNonNumbers(marketList.matchingItems[i].values().market_listing_item_name);
+
+                        const listingUI = $(getListingFromLists(listingid).elm);
+                        listingUI.addClass('not_checked');
+                       
                         marketRemoveQueue.push(listingid);
                         increaseMarketProgressMax();
                     }

--- a/code.user.js
+++ b/code.user.js
@@ -2667,7 +2667,6 @@
             const appid = listing.appid;
 
             let listingUI = getListingFromLists(listing.listingid);
-
             if (listingUI == null) {
                 logConsole(`Listing ${listing.listingid} not found in the lists, skipping.`);
 


### PR DESCRIPTION
This PR adds ability to skip prices load for removing items.

This will help:
- speed up removing
- making less requests to the server
- remove items while auto-relisting enabled