### PR TITLE
feat: add spinner in actions while inventory loads

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -1359,8 +1359,12 @@
         });
 
         function sellAllItems() {
+            renderSpinner('Processing items');
+
             loadAllInventories().then(
                 () => {
+                    removeSpinner();
+
                     const items = getInventoryItems();
                     const filteredItems = [];
 
@@ -1375,14 +1379,20 @@
                     sellItems(filteredItems);
                 },
                 () => {
+                    removeSpinner();
+
                     logDOM('Could not retrieve the inventory...');
                 }
             );
         }
 
         function sellAllDuplicateItems() {
+            renderSpinner('Processing items');
+
             loadAllInventories().then(
                 () => {
+                    removeSpinner();
+
                     const items = getInventoryItems();
                     const marketableItems = [];
                     let filteredItems = [];
@@ -1400,14 +1410,20 @@
                     sellItems(filteredItems);
                 },
                 () => {
+                    removeSpinner();
+
                     logDOM('Could not retrieve the inventory...');
                 }
             );
         }
 
         function gemAllDuplicateItems() {
+            renderSpinner('Processing items');
+
             loadAllInventories().then(
                 () => {
+                    removeSpinner();
+
                     const items = getInventoryItems();
                     let filteredItems = [];
                     let numberOfQueuedItems = 0;
@@ -1446,14 +1462,20 @@
                     }
                 },
                 () => {
+                    removeSpinner();
+
                     logDOM('Could not retrieve the inventory...');
                 }
             );
         }
 
         function sellAllCards() {
+            renderSpinner('Processing items');
+
             loadAllInventories().then(
                 () => {
+                    removeSpinner();
+
                     const items = getInventoryItems();
                     const filteredItems = [];
 
@@ -1468,14 +1490,20 @@
                     sellItems(filteredItems);
                 },
                 () => {
+                    removeSpinner();
+
                     logDOM('Could not retrieve the inventory...');
                 }
             );
         }
 
         function sellAllCrates() {
+            renderSpinner('Processing items');
+
             loadAllInventories().then(
                 () => {
+                    removeSpinner();
+
                     const items = getInventoryItems();
                     const filteredItems = [];
                     items.forEach((item) => {
@@ -1488,6 +1516,8 @@
                     sellItems(filteredItems);
                 },
                 () => {
+                    removeSpinner();
+
                     logDOM('Could not retrieve the inventory...');
                 }
             );
@@ -1627,7 +1657,11 @@
         function turnSelectedItemsIntoGems() {
             const ids = getSelectedItems();
 
+            renderSpinner('Processing items');
+
             loadAllInventories().then(() => {
+                removeSpinner();
+
                 const items = getInventoryItems();
 
                 let numberOfQueuedItems = 0;
@@ -1666,6 +1700,8 @@
                     renderSpinner(`Processing ${numberOfQueuedItems} items`);
                 }
             }, () => {
+                removeSpinner();
+
                 logDOM('Could not retrieve the inventory...');
             });
         }
@@ -1674,7 +1710,11 @@
         function unpackSelectedBoosterPacks() {
             const ids = getSelectedItems();
 
+            renderSpinner('Processing items');
+
             loadAllInventories().then(() => {
+                removeSpinner();
+
                 const items = getInventoryItems();
 
                 let numberOfQueuedItems = 0;
@@ -1713,6 +1753,8 @@
                     renderSpinner(`Processing ${numberOfQueuedItems} items`);
                 }
             }, () => {
+                removeSpinner();
+
                 logDOM('Could not retrieve the inventory...');
             });
         }

--- a/code.user.js
+++ b/code.user.js
@@ -1359,7 +1359,7 @@
         });
 
         function sellAllItems() {
-            renderSpinner('Processing items');
+            renderSpinner('Loading inventory items');
 
             loadAllInventories().then(
                 () => {
@@ -1387,7 +1387,7 @@
         }
 
         function sellAllDuplicateItems() {
-            renderSpinner('Processing items');
+            renderSpinner('Loading inventory items');
 
             loadAllInventories().then(
                 () => {
@@ -1418,7 +1418,7 @@
         }
 
         function gemAllDuplicateItems() {
-            renderSpinner('Processing items');
+            renderSpinner('Loading inventory items');
 
             loadAllInventories().then(
                 () => {
@@ -1470,7 +1470,7 @@
         }
 
         function sellAllCards() {
-            renderSpinner('Processing items');
+            renderSpinner('Loading inventory items');
 
             loadAllInventories().then(
                 () => {
@@ -1498,7 +1498,7 @@
         }
 
         function sellAllCrates() {
-            renderSpinner('Processing items');
+            renderSpinner('Loading inventory items');
 
             loadAllInventories().then(
                 () => {
@@ -1657,7 +1657,7 @@
         function turnSelectedItemsIntoGems() {
             const ids = getSelectedItems();
 
-            renderSpinner('Processing items');
+            renderSpinner('Loading inventory items');
 
             loadAllInventories().then(() => {
                 removeSpinner();
@@ -1710,7 +1710,7 @@
         function unpackSelectedBoosterPacks() {
             const ids = getSelectedItems();
 
-            renderSpinner('Processing items');
+            renderSpinner('Loading inventory items');
 
             loadAllInventories().then(() => {
                 removeSpinner();


### PR DESCRIPTION
Based on https://github.com/Nuklon/Steam-Economy-Enhancer/pull/290

This PR adds spinner while inventories loads, if user clicked actions buttons.
If inventory is large enough and it's not loaded yet, user might think that script is not doing anything after clicking buttons.

About redundant 'removeSpinner' - this is needed, because we can't use 'promise.finally' here.
Another spinner might been rendered already. It's fine, because every time spinner calls, the previous one removes.
But in case of code consistency, better to remove spinner explicitly.

Code can be a bit shorter, for example, removing errors block at 'loadAllInventories', because we don't actually awaits errors.
'loadAllInventories' will never reject, right now and before recent changes.
But this is the thing to dealt with at another place, not here. (https://github.com/Nuklon/Steam-Economy-Enhancer/issues/292)