### PR TITLE
feat(request): add soft failure tolerance

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -110,6 +110,7 @@
     }
 
     request.queue = [];
+    request.errors = 0;
     request.pending = false;
     request.stopped = false;
 
@@ -193,7 +194,13 @@
 
                 // Probably something broken, better to stop here.
                 if ([400, 401, 403, 404, 405, 429].includes(xhr.status)) {
-                    request.stopped = true;
+                    if (request.errors++ === 0) {
+                        setTimeout(() => request.errors = 0, 5 * 60 * 1000);
+                    }
+
+                    if (request.errors >= 5) {
+                        request.stopped = true;
+                    }
                 }
 
                 const next = () => {

--- a/code.user.js
+++ b/code.user.js
@@ -200,7 +200,6 @@
 
                     if (request.errors >= 5) {
                         request.stopped = true;
-
                         request.errors = 0;
                     }
                 }

--- a/code.user.js
+++ b/code.user.js
@@ -200,6 +200,8 @@
 
                     if (request.errors >= 5) {
                         request.stopped = true;
+
+                        request.errors = 0;
                     }
                 }
 


### PR DESCRIPTION
This PR adds a bit of tolerance for fatal errors.
Before this PR, request stops after first fatal error, now it's allows to get 5 errors until request will be stopped.

Reset-window chosen for 5 minutes, because other code blocks has delaying mechanism with 30-45s before retrying request. Plus some time for requests to the server. So, I guess 5 minutes is OK.

This can be useful, if:
- Steam performs background session refresh, while SEE sent request sent with old session data, in result - 401
(ref: https://community.fastly.steamstatic.com/public/shared/javascript/auth_refresh.js, session refreshes automatically, closer to jwt exp)
- User gets 429 error, which has reset-window in 1 minute (don't seen this in Steam, but it can be, and this is common everywhere)

Maybe additional delay management are also good here, for example `delay = 50000` (just in case), but I'm not sure.