### PR TITLE
refactor(inventory): remove loadAllInventories errors handling

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -1424,11 +1424,6 @@
                     });
 
                     sellItems(filteredItems);
-                },
-                () => {
-                    removeSpinner();
-
-                    logDOM('Could not retrieve the inventory...');
                 }
             );
         }
@@ -1455,11 +1450,6 @@
                     filteredItems = marketableItems.filter((e, i) => marketableItems.map((m) => m.classid).indexOf(e.classid) !== i);
 
                     sellItems(filteredItems);
-                },
-                () => {
-                    removeSpinner();
-
-                    logDOM('Could not retrieve the inventory...');
                 }
             );
         }
@@ -1507,11 +1497,6 @@
 
                         renderSpinner(`Processing ${numberOfQueuedItems} items`);
                     }
-                },
-                () => {
-                    removeSpinner();
-
-                    logDOM('Could not retrieve the inventory...');
                 }
             );
         }
@@ -1535,11 +1520,6 @@
                     });
 
                     sellItems(filteredItems);
-                },
-                () => {
-                    removeSpinner();
-
-                    logDOM('Could not retrieve the inventory...');
                 }
             );
         }
@@ -1561,11 +1541,6 @@
                     });
 
                     sellItems(filteredItems);
-                },
-                () => {
-                    removeSpinner();
-
-                    logDOM('Could not retrieve the inventory...');
                 }
             );
         }
@@ -1746,10 +1721,6 @@
 
                     renderSpinner(`Processing ${numberOfQueuedItems} items`);
                 }
-            }, () => {
-                removeSpinner();
-
-                logDOM('Could not retrieve the inventory...');
             });
         }
 
@@ -1798,9 +1769,6 @@
                         <div style="text-align:center">Processing ${numberOfQueuedItems} items</div>
                     </div>
                 `);
-            })
-            .catch(() => {
-                logDOM('Could not retrieve the inventory...');
             });
         }
 
@@ -1846,10 +1814,6 @@
 
                     renderSpinner(`Processing ${numberOfQueuedItems} items`);
                 }
-            }, () => {
-                removeSpinner();
-
-                logDOM('Could not retrieve the inventory...');
             });
         }
 
@@ -2117,8 +2081,6 @@
                 });
 
                 callback(filteredItems);
-            }, () => {
-                logDOM('Could not retrieve the inventory...');
             });
         }
 
@@ -2149,8 +2111,6 @@
                 });
 
                 callback(filteredItems);
-            }, () => {
-                logDOM('Could not retrieve the inventory...');
             });
         }
 
@@ -2181,8 +2141,6 @@
                 });
 
                 callback(filteredItems);
-            }, () => {
-                logDOM('Could not retrieve the inventory...');
             });
         }
 
@@ -2514,11 +2472,7 @@
                             updateInventoryPrices();
                         }
                     );
-                },
-                () => {
-                    logDOM('Could not retrieve the inventory...');
-                }
-            );
+                });
         }
 
         // Loads the specified inventories.

--- a/code.user.js
+++ b/code.user.js
@@ -1408,141 +1408,131 @@
         function sellAllItems() {
             renderSpinner('Loading inventory items');
 
-            loadAllInventories().then(
-                () => {
-                    removeSpinner();
+            loadAllInventories().then(() => {
+                removeSpinner();
 
-                    const items = getInventoryItems();
-                    const filteredItems = [];
+                const items = getInventoryItems();
+                const filteredItems = [];
 
-                    items.forEach((item) => {
-                        if (!item.marketable) {
-                            return;
-                        }
+                items.forEach((item) => {
+                    if (!item.marketable) {
+                        return;
+                    }
 
-                        filteredItems.push(item);
-                    });
+                    filteredItems.push(item);
+                });
 
-                    sellItems(filteredItems);
-                }
-            );
+                sellItems(filteredItems);
+            });
         }
 
         function sellAllDuplicateItems() {
             renderSpinner('Loading inventory items');
 
-            loadAllInventories().then(
-                () => {
-                    removeSpinner();
+            loadAllInventories().then(() => {
+                removeSpinner();
 
-                    const items = getInventoryItems();
-                    const marketableItems = [];
-                    let filteredItems = [];
+                const items = getInventoryItems();
+                const marketableItems = [];
+                let filteredItems = [];
 
-                    items.forEach((item) => {
-                        if (!item.marketable) {
-                            return;
-                        }
+                items.forEach((item) => {
+                    if (!item.marketable) {
+                        return;
+                    }
 
-                        marketableItems.push(item);
-                    });
+                    marketableItems.push(item);
+                });
 
-                    filteredItems = marketableItems.filter((e, i) => marketableItems.map((m) => m.classid).indexOf(e.classid) !== i);
+                filteredItems = marketableItems.filter((e, i) => marketableItems.map((m) => m.classid).indexOf(e.classid) !== i);
 
-                    sellItems(filteredItems);
-                }
-            );
+                sellItems(filteredItems);
+            });
         }
 
         function gemAllDuplicateItems() {
             renderSpinner('Loading inventory items');
 
-            loadAllInventories().then(
-                () => {
-                    removeSpinner();
+            loadAllInventories().then(() => {
+                removeSpinner();
 
-                    const items = getInventoryItems();
-                    let filteredItems = [];
-                    let numberOfQueuedItems = 0;
+                const items = getInventoryItems();
+                let filteredItems = [];
+                let numberOfQueuedItems = 0;
 
-                    filteredItems = items.filter((e, i) => items.map((m) => m.classid).indexOf(e.classid) !== i);
+                filteredItems = items.filter((e, i) => items.map((m) => m.classid).indexOf(e.classid) !== i);
 
-                    filteredItems.forEach((item) => {
-                        if (item.queued != null) {
-                            return;
-                        }
-
-                        if (item.owner_actions == null) {
-                            return;
-                        }
-
-                        let canTurnIntoGems = false;
-                        for (const owner_action in item.owner_actions) {
-                            if (item.owner_actions[owner_action].link != null && item.owner_actions[owner_action].link.includes('GetGooValue')) {
-                                canTurnIntoGems = true;
-                            }
-                        }
-
-                        if (!canTurnIntoGems) {
-                            return;
-                        }
-
-                        item.queued = true;
-                        scrapQueue.push(item);
-                        numberOfQueuedItems++;
-                    });
-
-                    if (numberOfQueuedItems > 0) {
-                        totalNumberOfQueuedItems += numberOfQueuedItems;
-
-                        renderSpinner(`Processing ${numberOfQueuedItems} items`);
+                filteredItems.forEach((item) => {
+                    if (item.queued != null) {
+                        return;
                     }
+
+                    if (item.owner_actions == null) {
+                        return;
+                    }
+
+                    let canTurnIntoGems = false;
+                    for (const owner_action in item.owner_actions) {
+                        if (item.owner_actions[owner_action].link != null && item.owner_actions[owner_action].link.includes('GetGooValue')) {
+                            canTurnIntoGems = true;
+                        }
+                    }
+
+                    if (!canTurnIntoGems) {
+                        return;
+                    }
+
+                    item.queued = true;
+                    scrapQueue.push(item);
+                    numberOfQueuedItems++;
+                });
+
+                if (numberOfQueuedItems > 0) {
+                    totalNumberOfQueuedItems += numberOfQueuedItems;
+
+                    renderSpinner(`Processing ${numberOfQueuedItems} items`);
                 }
-            );
+            });
         }
 
         function sellAllCards() {
             renderSpinner('Loading inventory items');
 
-            loadAllInventories().then(
-                () => {
-                    removeSpinner();
+            loadAllInventories().then(() => {
+                removeSpinner();
 
-                    const items = getInventoryItems();
-                    const filteredItems = [];
+                const items = getInventoryItems();
+                const filteredItems = [];
 
-                    items.forEach((item) => {
-                        if (!getIsTradingCard(item) || !item.marketable) {
-                            return;
-                        }
+                items.forEach((item) => {
+                    if (!getIsTradingCard(item) || !item.marketable) {
+                        return;
+                    }
 
-                        filteredItems.push(item);
-                    });
+                    filteredItems.push(item);
+                });
 
-                    sellItems(filteredItems);
-                }
-            );
+                sellItems(filteredItems);
+            });
         }
 
         function sellAllCrates() {
             renderSpinner('Loading inventory items');
 
-            loadAllInventories().then(
-                () => {
-                    removeSpinner();
+            loadAllInventories().then(() => {
+                removeSpinner();
 
-                    const items = getInventoryItems();
-                    const filteredItems = [];
-                    items.forEach((item) => {
-                        if (!getIsCrate(item) || !item.marketable) {
-                            return;
-                        }
-                        filteredItems.push(item);
-                    });
+                const items = getInventoryItems();
+                const filteredItems = [];
+                items.forEach((item) => {
+                    if (!getIsCrate(item) || !item.marketable) {
+                        return;
+                    }
+                    filteredItems.push(item);
+                });
 
-                    sellItems(filteredItems);
-                }
-            );
+                sellItems(filteredItems);
+            });
         }
 
         const scrapQueue = async.queue((item, next) => {
@@ -1726,8 +1716,7 @@
 
         // Unpacks all booster packs.
         function unpackAllBoosterPacks() {
-            loadAllInventories()
-            .then(() => {
+            loadAllInventories().then(() => {
                 const items = getInventoryItems();
 
                 let numberOfQueuedItems = 0;
@@ -2454,25 +2443,24 @@
                 }
             );
 
-            loadAllInventories().then(
-                () => {
-                    const updateInventoryPrices = function () {
-                        if (getSettingWithDefault(SETTING_INVENTORY_PRICE_LABELS) == 1) {
-                            setInventoryPrices(getInventoryItems());
-                        }
-                    };
+            loadAllInventories().then(() => {
+                const updateInventoryPrices = function () {
+                    if (getSettingWithDefault(SETTING_INVENTORY_PRICE_LABELS) == 1) {
+                        setInventoryPrices(getInventoryItems());
+                    }
+                };
 
-                    // Load after the inventory is loaded.
-                    updateInventoryPrices();
+                // Load after the inventory is loaded.
+                updateInventoryPrices();
 
-                    $('#inventory_pagecontrols').observe(
-                        'childlist',
-                        '*',
-                        () => {
-                            updateInventoryPrices();
-                        }
-                    );
-                });
+                $('#inventory_pagecontrols').observe(
+                    'childlist',
+                    '*',
+                    () => {
+                        updateInventoryPrices();
+                    }
+                );
+            });
         }
 
         // Loads the specified inventories.


### PR DESCRIPTION
ref: https://github.com/Nuklon/Steam-Economy-Enhancer/issues/292

`loadAllInventories` actually will never reject errors. It will hang indefinitely if error occurs.
I guess, that's fine, because we don't know the real cause of the error and probably don't want to do anything at this point.

About user notifications, like
```js
logDOM('Could not retrieve the inventory...')
```

There is no need about that, because Steam itself will notify user about an error, if was one.

Additionally, fixed code style in some places.