### PR TITLE
fix(ui): update sorting arrows in market listing tables

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -3404,8 +3404,8 @@
             let asc = true;
 
             // (Re)set the asc/desc arrows.
-            const arrow_down = '🡻';
-            const arrow_up = '🡹';
+            const arrow_down = '▼';
+            const arrow_up = '▲';
 
             $('.market_listing_table_header > span', elem).each(function () {
                 if ($(this).hasClass('market_listing_edit_buttons')) {


### PR DESCRIPTION
Previous one arrow were not visible at macOS.

New ones is not bad and visible at Windows and macOS (other os wasn't tested).