### PR TITLE
Remove two_factor param

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -946,7 +946,6 @@
                         language: 'english',
                         currency: currencyId,
                         item_nameid: item_nameid,
-                        two_factor: 0
                     }
                 };
 


### PR DESCRIPTION
If you check the request steam market sends, this param no longer exists, so removing it makes the url exactly same (good for caching).