### PR TITLE
Do not move market button if quick sell is disabled

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -156,7 +156,7 @@
             },
 
             /**
-             * 
+             *
              * @param {XMLHttpRequest} xhr - XMLHttpRequest object with additional jQuery properties.
              * @param {string} statusText - one of `error`, `abort`, `timeout` or `parsererror`.
              * @param {string} httpErrorText - textual portion of the HTTP status, in context of HTTP/2 it may be empty string.
@@ -2175,6 +2175,10 @@
         }
 
         async function updateInventorySelection(selectedItem) {
+            if (getSettingWithDefault(SETTING_QUICK_SELL_BUTTONS) != 1) {
+                return;
+            }
+
             const item_info = $(`#iteminfo${unsafeWindow.iActiveSelectView}`);
 
             if (!item_info.length) {
@@ -2185,20 +2189,13 @@
                 return;
             }
 
-            var timeDelayed = 0;
+            let timeDelayed = 0;
 
             // Wait until item_info is loaded.
             while (timeDelayed < 2500 && item_info.find('a[href^="https://steamcommunity.com/market/listings/"]').length == 0) {
                 await delay(100);
                 timeDelayed += 100;
             }
-
-            // Use a 'hard' item id instead of relying on the selected item_info (sometimes Steam temporarily changes the correct item (?)).
-            const item_info_id = item_info.attr('id');
-
-            // Move scrap to bottom, this is of little interest.
-            const scrap = $(`#${item_info_id}_scrap_content`);
-            scrap.next().insertBefore(scrap);
 
             // Skip unmarketable items
             if (!selectedItem.marketable) {
@@ -2231,10 +2228,6 @@
             if (isBoosterPack) {
                 const tradingCardsUrl = `/market/search?q=&category_753_Game%5B%5D=tag_app_${selectedItem.market_fee_app}&category_753_item_class%5B%5D=tag_item_class_2&appid=753`;
                 ownerActions.append(`<div style='display:flex'><a class="btn_small btn_grey_white_innerfade" href="${tradingCardsUrl}"><span>View trading cards in Community Market</span></a></div>`);
-            }
-
-            if (getSettingWithDefault(SETTING_QUICK_SELL_BUTTONS) != 1) {
-                return;
             }
 
             // Ignored queued items.


### PR DESCRIPTION
Also removes scrap code because that no longer works with React code.



I'm not entirely sure why the button 'View in Community Market' needs to be moved at all, but I changed it to only happen if you have quick sell enabled.



Also in react version they link individual cards to market pages on booster packs.

