### PR TITLE
feat: add specific page jump functionality to market history

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -3759,7 +3759,44 @@
             $('#see_settings').on('click', '*', () => openSettings());
 
             processMarketListings();
+            initializeMarketHistoryUI();
         }
+    }
+
+    // Initialize the market history UI.
+    function initializeMarketHistoryUI() {
+        // Use jquery-observe (already included in SEE) to listen for AJAX DOM updates
+        $('#tabContentsMyMarketHistory').observe('childlist subtree', function () {
+            const controlsDiv = $('#tabContentsMyMarketHistory_controls');
+
+            // Ensure the controls exist and we haven't already injected our jumper
+            if (controlsDiv.length > 0 && $('#custom_page_jumper').length === 0) {
+                const jumperContainer = $('<span id="custom_page_jumper"></span>');
+                const input = $('<input type="number" min="1" placeholder="Page" />');
+                const btn = $('<span class="btn_green_white_innerfade btn_small" style="cursor: pointer;"><span>Jump</span></span>');
+
+                jumperContainer.append(input).append(btn);
+                controlsDiv.append(jumperContainer);
+
+                btn.on('click', function () {
+                    const targetPage = parseInt(input.val());
+                    if (isNaN(targetPage) || targetPage < 1) {
+                        return; // Fail silently
+                    }
+                    const targetIndex = targetPage - 1;
+
+                    if (typeof unsafeWindow.g_oMyHistory !== 'undefined') {
+                        unsafeWindow.g_oMyHistory.GoToPage(targetIndex);
+                    }
+                });
+
+                input.on('keypress', function (e) {
+                    if (e.which === 13) { // Enter key
+                        btn.click();
+                    }
+                });
+            }
+        });
     }
     //#endregion
 
@@ -4122,6 +4159,9 @@
         #see_settings_modal select, #see_settings_modal input[type="number"] { background-color: black; color: white; border: transparent; padding: 4px 8px; }
         #see_settings_modal input[type="number"] { width: 100px; }
         #see_settings_modal input[type="checkbox"] { width: 16px; height: 16px; vertical-align: middle; accent-color: #000; }
+
+        #custom_page_jumper { margin-left: 15px; display: inline-block; }
+        #custom_page_jumper > input { width: 60px; margin-right: 8px; background-color: #1b2838; color: #fff; border: 1px solid #4582a5; padding: 2px 5px; }
     `);
 
     $(document).ready(() => {

--- a/code.user.js
+++ b/code.user.js
@@ -3770,13 +3770,13 @@
             const controlsDiv = $('#tabContentsMyMarketHistory_controls');
 
             // Ensure the controls exist and we haven't already injected our jumper
-            if (controlsDiv.length > 0 && $('#custom_page_jumper').length === 0) {
-                const jumperContainer = $('<span id="custom_page_jumper"></span>');
+            if (controlsDiv.length > 0 && $('#see_page_jump').length === 0) {
+                const jumpContainer = $('<span id="see_page_jump"></span>');
                 const input = $('<input type="number" min="1" placeholder="Page" />');
                 const btn = $('<span class="btn_green_white_innerfade btn_small" style="cursor: pointer;"><span>Jump</span></span>');
 
-                jumperContainer.append(input).append(btn);
-                controlsDiv.append(jumperContainer);
+                jumpContainer.append(input).append(btn);
+                controlsDiv.append(jumpContainer);
 
                 btn.on('click', () => {
                     const targetPage = parseInt(input.val());
@@ -4160,8 +4160,8 @@
         #see_settings_modal input[type="number"] { width: 100px; }
         #see_settings_modal input[type="checkbox"] { width: 16px; height: 16px; vertical-align: middle; accent-color: #000; }
 
-        #custom_page_jumper { margin-left: 15px; display: inline-block; }
-        #custom_page_jumper > input { width: 60px; margin-right: 8px; background-color: #1b2838; color: #fff; border: 1px solid #4582a5; padding: 2px 5px; }
+        #see_page_jump { margin-left: 15px; display: inline-block; }
+        #see_page_jump > input { width: 60px; margin-right: 8px; background-color: #1b2838; color: #fff; border: 1px solid #4582a5; padding: 2px 5px; }
     `);
 
     $(document).ready(() => {

--- a/code.user.js
+++ b/code.user.js
@@ -3766,7 +3766,7 @@
     // Initialize the market history UI.
     function initializeMarketHistoryUI() {
         // Use jquery-observe (already included in SEE) to listen for AJAX DOM updates
-        $('#tabContentsMyMarketHistory').observe('childlist subtree', function () {
+        $('#tabContentsMyMarketHistory').observe('childlist subtree', () => {
             const controlsDiv = $('#tabContentsMyMarketHistory_controls');
 
             // Ensure the controls exist and we haven't already injected our jumper
@@ -3778,7 +3778,7 @@
                 jumperContainer.append(input).append(btn);
                 controlsDiv.append(jumperContainer);
 
-                btn.on('click', function () {
+                btn.on('click', () => {
                     const targetPage = parseInt(input.val());
                     if (isNaN(targetPage) || targetPage < 1) {
                         return; // Fail silently
@@ -3790,7 +3790,7 @@
                     }
                 });
 
-                input.on('keypress', function (e) {
+                input.on('keypress', (e) => {
                     if (e.which === 13) { // Enter key
                         btn.click();
                     }


### PR DESCRIPTION
### Description
This PR adds a feature to the Steam Market History page: **Specific Page Jump functionality**. 

Currently, Steam only provides "Prev" and "Next" buttons. For users with extensive trading histories (sometimes tens of thousands of pages), navigating to older records is practically impossible. 

The code is completely isolated and does not interfere with or alter any existing features.

### Testing
Tested via Tampermonkey.
<img width="485" height="390" alt="jump2" src="https://github.com/user-attachments/assets/28d717fc-1928-4163-9825-62be31a49b41" />
<img width="484" height="395" alt="jump1" src="https://github.com/user-attachments/assets/02c39a8c-8f3c-4c57-a781-516b3d21bef4" />
