### PR TITLE
fix: multiple unnecessary calls to updateInventoryPrices()

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -2478,9 +2478,8 @@
                 // Load after the inventory is loaded.
                 updateInventoryPrices();
 
-                $('#inventory_pagecontrols').observe(
+                $('#pagecontrol_cur').observe(
                     'childlist',
-                    '*',
                     () => {
                         updateInventoryPrices();
                     }
@@ -3977,9 +3976,8 @@
             // Load after the inventory is loaded.
             updateInventoryPrices();
 
-            $('#inventory_pagecontrols').observe(
+            $('#pagecontrol_cur').observe(
                 'childlist',
-                '*',
                 () => {
                     updateInventoryPrices();
                 }


### PR DESCRIPTION
When switching pages in a trade offer the observer trigegrs twice and when switching pages in the inventory the observer triggers four times. Edited the observer so this doesn't happen.

Reduces unnecessary calls of updateInventoryPrices()