### PR TITLE
Add option to sell by average history only

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -499,13 +499,14 @@
 
         const shouldUseAverage = getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 1;
         const shouldUseBuyOrder = getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 3;
+        const shouldUseHistory = getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 4;
 
         // If the highest average price is lower than the first listing, return the offset + that listing.
         // Otherwise, use the highest average price instead.
         let calculatedPrice = 0;
         if (shouldUseBuyOrder && buyPrice !== -2) {
             calculatedPrice = buyPrice;
-        } else if (historyPrice < listingPrice || !shouldUseAverage) {
+        } else if ((historyPrice < listingPrice || !shouldUseAverage) && !shouldUseHistory) {
             calculatedPrice = listingPrice;
         } else {
             calculatedPrice = historyPrice;
@@ -528,9 +529,8 @@
         // Keep our minimum and maximum in mind.
         calculatedPrice = clamp(calculatedPrice, minPriceBeforeFees, maxPriceBeforeFees);
 
-
         // In case there's a buy order higher than the calculated price.
-        if (typeof orderbook !== 'undefined' && orderbook != null && orderbook.highest_buy_order != null) {
+        if (!shouldUseHistory && typeof orderbook !== 'undefined' && orderbook != null && orderbook.highest_buy_order != null) {
             const buyOrderPrice = market.getPriceBeforeFees(orderbook.highest_buy_order);
             if (buyOrderPrice > calculatedPrice) {
                 calculatedPrice = buyOrderPrice;
@@ -620,7 +620,7 @@
     // Prices are ordered by oldest to most recent.
     // Price is inclusive of fees.
     SteamMarket.prototype.getPriceHistory = function (item, cache, callback) {
-        const shouldUseAverage = getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 1;
+        const shouldUseAverage = (getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 1) || (getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 4);
 
         if (!shouldUseAverage) {
             // The price history is only used by the "average price" calculation
@@ -972,7 +972,8 @@
 
         price = Math.round(price);
         const feeInfo = CalculateFeeAmount(price, publisherFee, this.walletInfo);
-        return price - feeInfo.fees;
+
+        return (price > feeInfo.fees) ? price - feeInfo.fees : 1;
     };
 
     // Calculate the buyer price from the seller price
@@ -3997,6 +3998,7 @@
                     <option value="1"${getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 1 ? 'selected="selected"' : ''}>Maximum of the average history and lowest sell listing</option>
                     <option value="2" ${getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 2 ? 'selected="selected"' : ''}>Lowest sell listing</option>
                     <option value="3" ${getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 3 ? 'selected="selected"' : ''}>Highest current buy order or lowest sell listing</option>
+                    <option value="4" ${getSettingWithDefault(SETTING_PRICE_ALGORITHM) == 4 ? 'selected="selected"' : ''}>Average history only</option>
                 </select>
             </div>
             <div style="margin-top:6px;">


### PR DESCRIPTION
This PR adds one more option in price calculation - by average history only. After recent changes in some regions steam started to round up prices to the nearest unit, but previously put to sale items are still on market with old prices, and it's possible to set lower price via API (but not with steam website), at least for now. Because of that, if we take lowest selling price, or highest buy price, it's actually incorrect - because actual buying/selling price is lower, than displayed in market.
For example:

https://steamcommunity.com/market/listings/753/1037190-Lico
In Ukraine, it shows following prices in market:
Lowest sell order: 4₴
Highest buy order: 4₴
But if we check history, there are actual numbers shown, and it's easy to see that all recent purchases are below 3₴! Obviously, if we will put it for sale on 4₴, it would take forever to sell.
<img width="1186" height="815" alt="{8151C94E-F988-4170-8865-FF3BC2504CE0}" src="https://github.com/user-attachments/assets/f958bc82-c9b6-418d-81e2-44b0fd642b07" />
That's why none of currently available calculation methods will allow to sell it fast but cheap. My PR is aimed to fix that. I also added a failsafe for too small prices, that would result in a negative price before fees, and failed attempt to put item to sale (because minimal price in settings may be below that threshold). I also disabled for this method the check if lowest buy order is bigger than resulting price - because in affected regions it will (almost) always be reported as bigger.

Hope you'll find this PR useful and merge it, because keeping my for updated would require extra efforts for me, but changes are pretty basic and should not add maintenance burden for you.