### PR TITLE
Fix authenticated order book responses

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -926,15 +926,20 @@
             responseType: 'json'
         };
 
-        request(
-            url,
-            options,
-            (error, data) => {
-                if (error) {
-                    callback(ERROR_FAILED, null);
-                    return;
+        // Steam can return the full Market HTML page instead of JSON when
+        // authenticated cookies are sent to this otherwise public endpoint.
+        fetch(`${url}?${new URLSearchParams(options.data)}`, {
+            credentials: 'omit',
+            headers: { Accept: 'application/json' }
+        }).
+            then((response) => {
+                if (!response.ok) {
+                    throw new Error(`Order book request failed with status ${response.status}`);
                 }
 
+                return response.json();
+            }).
+            then((data) => {
                 const orderbook = buildOrderBook(data?.data);
                 if (orderbook == null) {
                     callback(ERROR_DATA, null);
@@ -946,8 +951,8 @@
                 storageSession.setItem(storage_hash, orderbook);
 
                 callback(ERROR_SUCCESS, orderbook, false);
-            }
-        );
+            }).
+            catch(() => callback(ERROR_FAILED, null));
     };
 
     // Calculate the price before fees (seller price) from the buyer price
@@ -2215,7 +2220,8 @@
                 }
             };
 
-            const isBoosterPack = selectedItem.name.toLowerCase().endsWith('booster pack');
+            const selectedItemName = selectedItem.name || selectedItem.description?.name || '';
+            const isBoosterPack = selectedItemName.toLowerCase().endsWith('booster pack');
             if (isBoosterPack) {
                 const tradingCardsUrl = `/market/search?q=&category_753_Game%5B%5D=tag_app_${selectedItem.market_fee_app}&category_753_item_class%5B%5D=tag_item_class_2&appid=753`;
                 const communityHeader = $('h1', item_info).next().find('span').eq(0);


### PR DESCRIPTION
## Summary

- fetch the public `/market/orderbook` endpoint without authenticated cookies
- fall back to `selectedItem.description.name` while Steam is still building the flattened inventory item

## Root cause

For some authenticated Steam sessions, `/market/orderbook` returns the full Steam Market HTML page with HTTP 200 instead of JSON. The same URL returns the expected JSON when credentials are omitted. Because the userscript requests `dataType: 'json'`, jQuery reports a parser error; inventory price labels never appear and automated sell workflows repeatedly retry.

Steam can also invoke `CInventory.prototype.SelectItem` before the selected asset has been flattened. At that point `selectedItem.name` is undefined while `selectedItem.description.name` is available, causing `updateInventorySelection` to throw before quick-sell controls are rendered.

## Changes

- use `fetch(..., { credentials: 'omit' })` for the public order-book request and keep the existing response parsing, caching, and callback behavior
- derive the booster-pack name from either the flattened asset or its description

## Impact

Restores inventory price labels, quick-sell controls, and automated selling for affected authenticated sessions without changing authenticated requests used for actual market actions.

## Validation

- reproduced the HTML-vs-JSON behavior in an authenticated browser session
- confirmed cookie-free order-book requests return valid JSON
- verified the patched userscript in the affected inventory; the reporter confirmed the fix works
- `node --check code.user.js`
- `npm test`

Related to #332.
