### PR TITLE
Fix: Relist overpriced does nothing when a listing is awaiting confirmation

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -3535,7 +3535,14 @@
             marketProgressBar = document.getElementById('see_market_progress');
 
             // Sell orders.
-            $('.my_market_header').first().append(`<div class="market_listing_buttons">
+            // Steam prepends a "listings awaiting confirmation" block whenever a confirmation is pending,
+            // so the sell listings are not always the first header. Anchor to the sell listings table itself.
+            const sellListingsHeader = $('#tabContentsMyActiveMarketListingsRows').
+                closest('.market_home_listing_table').
+                find('.my_market_header').
+                first();
+
+            sellListingsHeader.append(`<div class="market_listing_buttons">
                 <a class="item_market_action_button item_market_action_button_green select_all market_listing_button">
                     <span class="item_market_action_button_contents">Select all</span>
                 </a>
@@ -3560,7 +3567,7 @@
             </div>`);
 
             // Listings confirmations and buy orders.
-            $('.my_market_header').slice(1).append(`<div class="market_listing_buttons">
+            $('.my_market_header').not(sellListingsHeader).append(`<div class="market_listing_buttons">
                 <a class="item_market_action_button item_market_action_button_green select_all market_listing_button">
                     <span class="item_market_action_button_contents">Select all</span>
                 </a>


### PR DESCRIPTION
### The problem

`Relist overpriced` silently does nothing whenever you have at least one listing awaiting confirmation.

`initializeMarketUI()` places the sell-listing buttons positionally:

```js
$('.my_market_header').first()    // assumed to be "My sell listings"
$('.my_market_header').slice(1)   // everything else
```

Steam renders the **My listings awaiting confirmation** block *before* the sell listings whenever a confirmation is pending. The full button set, including `Relist overpriced`, is therefore attached to that block, while the sell listings only get `Select all` and `Remove selected`.

The handler itself is fine. It just iterates the awaiting-confirmation list, finds nothing carrying the `overpriced` class, and returns. That is why the button appears dead. It works again as soon as your confirmation queue is empty, which is what makes this look intermittent.

### Evidence

On a market page with 148 sell listings and 1 pending confirmation:

| Table | Buttons attached | `.overpriced` rows |
| --- | --- | --- |
| *My listings awaiting confirmation* | Select all, Select 5, Select 25, Remove selected, **Relist selected, Relist overpriced, Select overpriced** | **0** |
| `#tabContentsMyActiveMarketListingsTable` (*My sell listings*) | Select all, Remove selected | **1** |

The pricing pipeline was never involved: 15 rows priced, 1 overpriced, 1 underpriced, 13 fair.

Clicking `Select overpriced` where it currently sits selected 0 rows. Moving the identical button node into the sell-listings header and clicking it selected exactly the 1 overpriced row. Same button, same handler, only the parent table differs.

### The fix

Anchor to the sell-listings table via `#tabContentsMyActiveMarketListingsRows`, an id this file already relies on in four other places, instead of depending on header order:

```js
const sellListingsHeader = $('#tabContentsMyActiveMarketListingsRows').
    closest('.market_home_listing_table').
    find('.my_market_header').
    first();

sellListingsHeader.append(...);                             // full set
$('.my_market_header').not(sellListingsHeader).append(...); // reduced set
```

Verified against a live market page: the new selector resolves to exactly one header (*My sell listings*), and `.not()` yields exactly the other two (confirmations, buy orders). ESLint passes.

### Note

`getSpinnerContext()` uses `$('.my_market_header').eq(0)` and has the same root cause, which is why the loading spinner renders under the awaiting-confirmation section. It is cosmetic only, so I left it out to keep this change to one thing.
