### PR TITLE
Feedback on the overpriced buttons: live count, relist progress, jQuery 4

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -10,8 +10,8 @@
 // @match        https://steamcommunity.com/profiles/*/inventory*
 // @match        https://steamcommunity.com/market*
 // @match        https://steamcommunity.com/tradeoffer*
-// @require      https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js
-// @require      https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.14.1/jquery-ui.min.js
+// @require      https://cdnjs.cloudflare.com/ajax/libs/jquery/4.0.0/jquery.min.js
+// @require      https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.14.2/jquery-ui.min.js
 // @require      https://cdnjs.cloudflare.com/ajax/libs/async/3.2.6/async.js
 // @require      https://cdnjs.cloudflare.com/ajax/libs/localforage/1.10.0/localforage.min.js
 // @require      https://cdnjs.cloudflare.com/ajax/libs/luxon/3.5.0/luxon.min.js

--- a/code.user.js
+++ b/code.user.js
@@ -2600,6 +2600,11 @@
         const marketListingsRelistedAssets = [];
         let marketProgressBar;
 
+        // Progress of the current relist run, shown on the relist overpriced button.
+        // Both are reset when the relist queue drains.
+        let marketRelistTotal = 0;
+        let marketRelistDone = 0;
+
         function increaseMarketProgressMax() {
             let value = marketProgressBar.max;
 
@@ -2838,6 +2843,8 @@
                     false,
                     (success) => {
                         const callback = () => {
+                            marketRelistDone += 1;
+
                             increaseMarketProgress();
                             next();
                         };
@@ -2852,6 +2859,14 @@
             },
             1
         );
+
+        // The relist run finished, put the buttons back to showing the (now lower) overpriced count.
+        marketOverpricedQueue.drain(() => {
+            marketRelistTotal = 0;
+            marketRelistDone = 0;
+
+            updateMarketOverpricedButtons();
+        });
 
         function marketOverpricedQueueWorker(item, ignoreErrors, callback) {
             let listingUI = getListingFromLists(item.listing)
@@ -2951,7 +2966,11 @@
                     appid: assetInfo.appid,
                     sellPrice: price
                 });
+
+                marketRelistTotal += 1;
+
                 increaseMarketProgressMax();
+                updateMarketOverpricedButtons();
             }
         }
 
@@ -3380,7 +3399,13 @@
         // Shows the number of overpriced listings on the overpriced buttons.
         // The count is taken from the matching items so it reflects exactly what the buttons act on,
         // which means it follows the search filter.
+        //
+        // While a relist run is in progress the relist button shows its progress instead of the count,
+        // and is marked busy so it cannot queue the same listings twice. Relist selected and the
+        // automatic relist share this queue, so they show their progress here as well.
         function updateMarketOverpricedButtons() {
+            const isRelisting = marketRelistTotal > 0;
+
             $('.market_listing_buttons').each(function () {
                 const selectionGroup = $(this).parent().parent();
                 const marketList = getListFromContainer(selectionGroup);
@@ -3391,7 +3416,12 @@
 
                 const count = marketList.matchingItems.filter(item => $(item.elm).hasClass('overpriced')).length;
 
-                $('.relist_overpriced > span', selectionGroup).text(`Relist overpriced (${count})`);
+                $('.relist_overpriced > span', selectionGroup).text(isRelisting
+                    ? `Relisting ${marketRelistDone}/${marketRelistTotal}`
+                    : `Relist overpriced (${count})`);
+
+                $('.relist_overpriced, .relist_selected', selectionGroup).toggleClass('see_button_busy', isRelisting);
+
                 $('.select_overpriced > span', selectionGroup).text(`Select overpriced (${count})`);
             });
         }
@@ -3550,6 +3580,10 @@
                 marketLists[i].remove('market_listing_item_name', `mylisting_${listingid}_name`);
                 marketLists[i].remove('market_listing_item_name', `mbuyorder_${listingid}_name`);
             }
+
+            // Listings are removed from the lists a few seconds after they are relisted or removed,
+            // which can be after the queue drained, so refresh the counts here as well.
+            updateMarketOverpricedButtons();
         }
 
         // Initialize the market UI.
@@ -3721,6 +3755,10 @@
             });
 
             $('.relist_overpriced').on('click', '*', function () {
+                if ($(this).closest('.relist_overpriced').hasClass('see_button_busy')) {
+                    return;
+                }
+
                 const selectionGroup = $(this).parent().parent().parent().parent();
                 const marketList = getListFromContainer(selectionGroup);
 
@@ -3737,6 +3775,10 @@
             });
 
             $('.relist_selected').on('click', '*', function () {
+                if ($(this).closest('.relist_selected').hasClass('see_button_busy')) {
+                    return;
+                }
+
                 const selectionGroup = $(this).parent().parent().parent().parent();
                 const marketList = getListFromContainer(selectionGroup);
 
@@ -4152,6 +4194,7 @@
         .see_inventory_buttons > .see_inventory_buttons, .see_inventory_buttons > #inventory_items_spinner {flex-basis: 100%;}
         #see_market_progress { display: block; width: 50%; height: 20px; }
         #see_market_progress[hidden] { visibility: hidden; }
+        .item_market_action_button.see_button_busy { pointer-events: none; opacity: 0.6; cursor: default; }
 
         #see_settings { background: #26566c; margin-right: 10px; height: 24px; line-height:24px; display:inline-block; padding: 0px 6px; }
         #see_settings_modal select, #see_settings_modal input[type="number"] { background-color: black; color: white; border: transparent; padding: 4px 8px; }

--- a/code.user.js
+++ b/code.user.js
@@ -3535,7 +3535,14 @@
             marketProgressBar = document.getElementById('see_market_progress');
 
             // Sell orders.
-            $('.my_market_header').first().append(`<div class="market_listing_buttons">
+            // Steam prepends a "listings awaiting confirmation" block whenever a confirmation is pending,
+            // so the sell listings are not always the first header. Anchor to the sell listings table itself.
+            const sellListingsHeader = $('#tabContentsMyActiveMarketListingsRows').
+                closest('.market_home_listing_table').
+                find('.my_market_header').
+                first();
+
+            sellListingsHeader.append(`<div class="market_listing_buttons">
                 <a class="item_market_action_button item_market_action_button_green select_all market_listing_button">
                     <span class="item_market_action_button_contents">Select all</span>
                 </a>
@@ -3560,7 +3567,7 @@
             </div>`);
 
             // Listings confirmations and buy orders.
-            $('.my_market_header').slice(1).append(`<div class="market_listing_buttons">
+            $('.my_market_header').not(sellListingsHeader).append(`<div class="market_listing_buttons">
                 <a class="item_market_action_button item_market_action_button_green select_all market_listing_button">
                     <span class="item_market_action_button_contents">Select all</span>
                 </a>

--- a/code.user.js
+++ b/code.user.js
@@ -2619,6 +2619,9 @@
             if (marketProgressBar.value === marketProgressBar.max) {
                 marketProgressBar.setAttribute('hidden', 'true');
             }
+
+            // A listing was just priced, relisted or removed, so the overpriced count may have changed.
+            updateMarketOverpricedButtons();
         }
 
         // Match number part from any currency format
@@ -3258,6 +3261,7 @@
             try {
                 const list = new List(market_listing_see.parent().get(0), options);
                 list.on('searchComplete', updateMarketSelectAllButton);
+                list.on('searchComplete', updateMarketOverpricedButtons);
                 marketLists.push(list);
             } catch (e) {
                 console.error(e);
@@ -3370,6 +3374,25 @@
                     invert = false;
                 }
                 $('.select_all > span', selectionGroup).text(invert ? 'Deselect all' : 'Select all');
+            });
+        }
+
+        // Shows the number of overpriced listings on the overpriced buttons.
+        // The count is taken from the matching items so it reflects exactly what the buttons act on,
+        // which means it follows the search filter.
+        function updateMarketOverpricedButtons() {
+            $('.market_listing_buttons').each(function () {
+                const selectionGroup = $(this).parent().parent();
+                const marketList = getListFromContainer(selectionGroup);
+
+                if (marketList == null) {
+                    return;
+                }
+
+                const count = marketList.matchingItems.filter(item => $(item.elm).hasClass('overpriced')).length;
+
+                $('.relist_overpriced > span', selectionGroup).text(`Relist overpriced (${count})`);
+                $('.select_overpriced > span', selectionGroup).text(`Select overpriced (${count})`);
             });
         }
 
@@ -3559,10 +3582,10 @@
                     <span class="item_market_action_button_contents">Relist selected</span>
                 </a>
                 <a class="item_market_action_button item_market_action_button_green relist_overpriced market_listing_button">
-                    <span class="item_market_action_button_contents">Relist overpriced</span>
+                    <span class="item_market_action_button_contents">Relist overpriced (0)</span>
                 </a>
                 <a class="item_market_action_button item_market_action_button_green select_overpriced market_listing_button">
-                    <span class="item_market_action_button_contents">Select overpriced</span>
+                    <span class="item_market_action_button_contents">Select overpriced (0)</span>
                 </a>
             </div>`);
 


### PR DESCRIPTION
> **Stacked on #334.** Please merge #334 first. Until then this PR shows #334's commit as well; afterwards its diff collapses to the three commits below. GitHub will not let a cross-fork PR use another fork branch as its base, hence the flat stack.

Three commits, reviewable independently.

---

### 1. `feat: show the overpriced count on the overpriced buttons`

The buttons read `Relist overpriced (35)` and `Select overpriced (35)`.

The count comes from the list's `matchingItems` rather than every row, so it reflects exactly what the buttons act on and follows the search filter. It refreshes whenever the market progress advances, which covers listings being priced, relisted or removed, and on `searchComplete`.

### 2. `chore: update to jQuery 4.0.0 and jQuery UI 1.14.2`

jQuery UI 1.14.2 declares `jquery: ">=1.12.0 <5.0.0"`, so it pairs with jQuery 4.

I diffed the two jQuery versions rather than working from the upgrade notes. Actual removals are `$.trim`, `$.type`, `$.now`, `$.isArray`, `$.isFunction`, `$.isNumeric`, `$.isWindow`, `$.nodeName`, `$.camelCase`, `$.parseJSON`, `$.unique`, `$.cssNumber`, `$.cssProps`, plus the `push`/`sort`/`splice` instance methods. None are used by `code.user.js`, `jquery-observe` or `checkboxes.js`. The `$.ajax` options in use (`type`, `data`, `dataType`, `success`, `error`, `complete`) all survive.

Because the two `@require`d plugins are pinned to old commits and cannot be upgraded, I exercised them against jQuery 4.0.0 in a browser:

| Check | Result |
| --- | --- |
| jQuery UI loads alongside jQuery 4 | `$.ui.version === "1.14.2"` |
| `.selectable()`, the only UI widget used | initializes clean |
| `jquery-observe` `.observe()`, used in 4 places | fires on mutation |
| `checkboxes('range')` | identical result to 3.7.1 |
| `$.noConflict(true)` | present |

### 3. `feat: show relist progress on the relist overpriced button`

Relisting runs for minutes on a large batch, but the only feedback was the progress bar in the market banner, roughly 1200px above the buttons on a page over 11000px tall, so a relist looked like it did nothing.

While the relist queue is busy the button reads `Relisting 3/35`, and both relist buttons are marked busy: greyed out, with the click handlers returning early so the same listings cannot be queued twice. The queue's `drain` callback resets the counters and restores the idle count.

Verified through real `async` 3.2.6 with the actual label logic:

```
idle           relist="Relist overpriced (3)"  busy=false
clicked        relist="Relisting 0/3"          busy=true
after item 1   relist="Relisting 1/3"          busy=true
after item 2   relist="Relisting 2/3"          busy=true
after item 3   relist="Relisting 3/3"          busy=true
drain          relist="Relist overpriced (…)"  busy=false
```

Two things worth knowing:

- The counters track attempts, not successes. A failed relist retries inside the same queue item after 30 to 45 seconds, so the number advances only once an item settles.
- `Relist selected` and the automatic relist share this queue and report their progress here too. With auto-relist enabled, `drain` fires between trickled-in items, so the label returns to idle between them rather than showing one continuous run.

`removeListingFromLists()` now refreshes the counts, because listings leave the lists a few seconds after being relisted or removed, which can be after the queue has drained.